### PR TITLE
Updated 7 Louisiana Breweries

### DIFF
--- a/data/united-states/louisiana.csv
+++ b/data/united-states/louisiana.csv
@@ -1,19 +1,19 @@
 id,name,brewery_type,address_1,address_2,address_3,city,state_province,postal_code,country,phone,website_url,longitude,latitude
 c074ba4c-0b31-4344-a85a-7930df7fb410,Abita Brewing Co,regional,166 Barbee Rd,,,Covington,Louisiana,70433-8651,United States,9858933143,http://www.abita.com,-90.056477,30.481981
-faabb5c6-fc44-4300-84cd-66f8af67e8fd,Bayou Teche Brewing,micro,1094 Bushville Hwy,,,Arnaudville,Louisiana,70512-3526,United States,3373038117,http://www.bayoutechebrewing.com,,
+faabb5c6-fc44-4300-84cd-66f8af67e8fd,Bayou Teche Brewing,micro,1002 Noth Lane,,,Arnaudville,Louisiana,70512,United States,3377545122,http://www.bayoutechebrewing.com,-91.925099,30.391754
 887aaeec-884a-4a60-986a-daf4333cca08,Brasserie L'Etrange,planning,,,,Prairieville,Louisiana,70769-6114,United States,2258002337,,,
 1d80031e-2255-4467-8cd2-cd8e3194289e,Brieux Carre Brewing Company,micro,2115 Decatur St,,,New Orleans,Louisiana,70116,United States,5043044242,http://www.brieuxcarre.com,-90.0572496,29.9627851
 cab32ebd-9d23-425f-ad99-fc0959be6858,Broken Wheel Brewery,brewpub,109 Tunica Dr E,,,Marksville,Louisiana,71351-3005,United States,3182536543,,-92.06931518,31.12386287
 6265172a-55a2-405b-8a59-efbd4de3adfd,Cajun Brewing,micro,206 Rayburn St,,,Lafayette,Louisiana,70506-4130,United States,3378069196,http://www.cajunbrewing.com,-92.04978922,30.21549043
-604378f2-9c18-4ac2-bd4b-206f4423d9ea,"Cane River Brewing Co., L.L.C",planning,,,,Natchitoches,Louisiana,71457,United States,3184719115,http://www.caneriverbrewing.com,,
+604378f2-9c18-4ac2-bd4b-206f4423d9ea,"Cane River Brewing Co., L.L.C",closed,,,,Natchitoches,Louisiana,71457,United States,3184719115,http://www.caneriverbrewing.com,,
 27baa23f-707d-40e8-98f5-64f94b3f19ad,Chafunkta Brewing Co,micro,69123 Skybrook Rd. STE E,,,Mandeville,Louisiana,70471-7777,United States,9858690716,http://www.chafunkta.com,-90.035658,30.432895
 d672e35e-6486-4d98-9343-994e67768660,Chappapeela Farms Brewery,micro,57542 Hillcrest School Rd,,,Amite,Louisiana,70422-4922,United States,2252819474,http://www.chapbrewery.com,,
-11ca4b21-c34e-4857-9434-b1f264140524,Covington Brewhouse,micro,226 E Lockwood St,,,Covington,Louisiana,70433-2828,United States,9858932884,http://www.covingtonbrewhouse.com,-90.0970557,30.47766326
+11ca4b21-c34e-4857-9434-b1f264140524,Covington Brewhouse,closed,226 E Lockwood St,,,Covington,Louisiana,70433-2828,United States,9858932884,http://www.covingtonbrewhouse.com,-90.0970557,30.47766326
 f7de41dc-b46c-4ab5-82bd-c437e685b48f,Crescent City Brewhouse,brewpub,527 Decatur St,,,New Orleans,Louisiana,70130-1027,United States,5045220571,http://www.crescentcitybrewhouse.com,-90.0639242,29.9557185
 534c0a74-1e1a-422a-894a-1fe55ea95af4,Crying Eagle Brewing Company,micro,1165 E McNeese St,,,Lake Charles,Louisiana,70607-4753,United States,3379904871,http://www.cryingeagle.com,-93.20515133,30.17626439
 e6e3663e-f931-44f1-ba5b-a9191f3eef41,Deadbeat Brewing Co,micro,14258 W Club Deluxe Rd,,,Hammond,Louisiana,70403,United States,9856620445,https://deadbeatbrewing.company.site,-90.492386,30.475008
-ee957438-dbb4-4cc4-8731-d3482d3a4775,Dixie Brewing Co Inc.,contract,6221 S Claiborne Ave Ste 101,,,New Orleans,Louisiana,70125-4191,United States,5048228711,,,
-2795f339-b872-44dd-af71-e79550711989,"Dixie Brewing Company, LLC",contract,1450 Poydras St Ste 580,,,New Orleans,Louisiana,70112-1227,United States,5059176071,http://www.dixiebeer.com,,
+ee957438-dbb4-4cc4-8731-d3482d3a4775,Dixie Brewing Co Inc.,closed,6221 S Claiborne Ave Ste 101,,,New Orleans,Louisiana,70125-4191,United States,5048228711,,,
+2795f339-b872-44dd-af71-e79550711989,"Dixie Brewing Company, LLC",closed,1450 Poydras St Ste 580,,,New Orleans,Louisiana,70112-1227,United States,5059176071,http://www.dixiebeer.com,,
 230482be-8886-42e9-b6ae-25948beba74c,Flying Heart Brewing,micro,700 Barksdale Blvd,,,Bossier City,Louisiana,71111-4502,United States,3183448775,http://www.flyingheartbrewing.com,-93.732075,32.515706
 220b8569-7203-42e3-8c6a-1565f5ba0f2f,Flying Tiger Brewery,micro,506 N 2nd St,,,Monroe,Louisiana,71201-6234,United States,3185471738,http://www.flyingtigerbeer.com,-92.11970662,32.50586475
 a33083eb-89f0-465e-979f-4990cccb47dd,Folsom Brewery,planning,,,,Folsom,Louisiana,70437-,United States,9853737631,,,
@@ -22,7 +22,7 @@ a2735f3a-dfe8-4c31-86df-9e1b19734faf,Gordon Biersch Brewery Restaurant - New Orl
 457a1fd7-e41f-4229-9c47-0ad74fb4ed90,Great Raft Brewing,micro,1251 Dalzell St,,,Shreveport,Louisiana,71103-3705,United States,3187348101,http://www.greatraftbrewing.com,-93.75545669,32.48900686
 d4a8d201-e4ce-4f5e-ad83-b3f3d43cf5dd,High Ground Brewery,planning,,,,Saint Francisville,Louisiana,70775-2431,United States,2254457436,,,
 88a92055-2ca5-40d7-8f6c-d6f7b28b6fa7,Huckleberry Brewing Company,micro,4724 Sterkx Rd,,,Alexandria,Louisiana,71301,United States,3187046833,http://www.huckleberrybrewingco.com,-92.45332257,31.26477666
-a35771c8-3596-4ac0-99b1-d00a400cd923,Le Chien Brewing Company,planning,,,,Greenwell Springs,Louisiana,70739,United States,,http://www.lechien.beer,,
+a35771c8-3596-4ac0-99b1-d00a400cd923,Le Chien Brewing Company,micro,101 S Hummell St,,,Denham Springs,Louisiana,70726,United States,7815324436,http://www.lechien.beer,-90.955370,30.483981
 7fd0b5f9-cf63-4db1-b797-fe50461dcbc5,Mudbug Brewery,micro,1878 LA Hwy 3185,,,Thibodaux,Louisiana,70302-1077,United States,9854921610,http://www.mudbugbrewery.com,,
 9eb2f4e3-a109-438b-8a64-61b3d572488c,New Orleans Lager and Ale Brewing (NOLA Brewing),micro,3001 Tchoupitoulas St,,,New Orleans,Louisiana,70115-1039,United States,5048969996,http://www.nolabrewing.com,-90.08141776,29.9199522
 ebc2f1b3-852f-4e01-b412-09a669cd0c7f,Old Rail Brewing Co,closed,639 Girod St,,,Mandeville,Louisiana,70448-5205,United States,9856121828,http://www.oldrailbrewing.com,-90.06386106,30.35985466
@@ -35,10 +35,10 @@ f66e0f8c-af6d-4f0b-a2f0-53f279062189,Pub Craught,planning,,,,Baton Rouge,Louisia
 5d6cbdd3-2315-469c-a97f-e87ee1cbbd35,Royal Brewery,micro,7366 Townsend Pl Ste B,,,New Orleans,Louisiana,70126-1138,United States,5044158444,http://WWW.royalbrewerynola.com,,
 18f65032-7043-4c44-9df9-78a396be1572,Sawbriar Brewery,planning,,,,Lafayette,Louisiana,70501,United States,3373403308,http://www.sawbriarbrewery.com,,
 96a8eaad-4862-447e-a4ab-8a2a38bddc12,Second Line Brewing,micro,433 N Bernadotte St,,,New Orleans,Louisiana,70119-4311,United States,5042488979,http://www.secondlinebrewing.com,-90.1056073,29.9825676
-4ef9f5b8-3d53-4339-84e6-76f0ba810e27,Southern Craft Brewing Company,micro,14141 Airline Hwy Ste 4J,,,Baton Rouge,Louisiana,70817-6259,United States,2256638119,http://www.socraftbeer.com,,
+4ef9f5b8-3d53-4339-84e6-76f0ba810e27,Southern Craft Brewing Company,closed,14141 Airline Hwy Ste 4J,,,Baton Rouge,Louisiana,70817-6259,United States,2256638119,http://www.socraftbeer.com,,
 d607f1e5-cce4-4fe4-a6bf-6ad2b0bfa19d,Spigots Brew Pub,brewpub,622 Barrow St,,,Houma,Louisiana,70360-4608,United States,9853333103,http://www.spigotsbrewpub.com,-90.71974565,29.59396551
 292d1371-649e-4412-b2c5-8b9eeaf71cb3,The Courtyard Brewery,micro,1020 Erato St,,,New Orleans,Louisiana,70130-4112,United States,,http://www.courtyardbrew.com,-90.07054452,29.9387632
-e46f6a31-62ee-4635-ad2d-d03ed6f0d69c,The Seventh Tap Brewing Project,planning,,,,Bossier City,Louisiana,71112,United States,3184025188,http://www.theseventhtap.com,,
+e46f6a31-62ee-4635-ad2d-d03ed6f0d69c,The Seventh Tap Brewing Project,micro,2640 Linwood Ave,,,Shreveport,Louisiana,71103,United States,3187544471,http://www.theseventhtap.com,-93.762508,32.486727
 f8d441be-c395-485d-bc40-97fb4182e1e4,Tin Roof Brewing Co,micro,1624 Wyoming St,,,Baton Rouge,Louisiana,70802-8514,United States,2253777022,http://www.tinroofbeer.com,-91.1884332,30.419556
 bfbcc407-1328-4791-bf71-7cc77e2a5feb,Urban South Brewery,micro,1645 Tchoupitoulas St,,,New Orleans,Louisiana,70130-1852,United States,,http://www.urbansouthbrewery.com,-90.0666607,29.9296799
 cfd51d05-11a3-487f-af99-ce3ce3f4ee2f,Utility Brewing Company,brewpub,206 N. Vienna Street,,,Ruston,Louisiana,71270,United States,,http://www.utilitybrewing.com,-92.63790404,32.52986335


### PR DESCRIPTION
7 locations updated. Covington Brewhouse, Southern Craft Brewing, Dixie Brewing, and Cane River Brewing closed. Status changes with coordinates to The Seventh Tap Brewing Project, Le Chien, and Bayou Teche.